### PR TITLE
Fix tokenizing of comments starting or ending with more than two --

### DIFF
--- a/src/evented-tokenizer.ts
+++ b/src/evented-tokenizer.ts
@@ -379,7 +379,7 @@ export default class EventedTokenizer {
     commentStart() {
       let char = this.consume();
 
-      if (char === '-') {
+      if (char === '-' && this.peek() === '-') {
         this.transitionTo(TokenizerState.commentStartDash);
       } else if (char === '>') {
         this.delegate.finishComment();
@@ -417,7 +417,9 @@ export default class EventedTokenizer {
     commentEndDash() {
       let char = this.consume();
 
-      if (char === '-') {
+      if (char === '-' && this.peek() === '-') {
+        this.delegate.appendToCommentData(char);
+      } else if (char === '-') {
         this.transitionTo(TokenizerState.commentEnd);
       } else {
         this.delegate.appendToCommentData('-' + char);

--- a/tests/tokenizer-tests.ts
+++ b/tests/tokenizer-tests.ts
@@ -324,11 +324,48 @@ QUnit.test('A comment that immediately closes', function(assert) {
 QUnit.test('A comment that contains a -', function(assert) {
   let tokens = tokenize('<!-- A perfectly legal - appears -->');
   assert.deepEqual(tokens, [comment(' A perfectly legal - appears ')]);
+
+  tokens = tokenize('<!-- A perfectly legal - -->');
+  assert.deepEqual(tokens, [comment(' A perfectly legal - ')]);
+
+  tokens = tokenize('<!-- A perfectly legal- -->');
+  assert.deepEqual(tokens, [comment(' A perfectly legal- ')]);
 });
 
 QUnit.test('A (buggy) comment that contains two --', function(assert) {
   let tokens = tokenize('<!-- A questionable -- appears -->');
   assert.deepEqual(tokens, [comment(' A questionable -- appears ')]);
+
+  tokens = tokenize('<!-- A questionable -- -->');
+  assert.deepEqual(tokens, [comment(' A questionable -- ')]);
+
+  tokens = tokenize('<!-- A questionable-- -->');
+  assert.deepEqual(tokens, [comment(' A questionable-- ')]);
+});
+
+QUnit.test('A (buggy) comment ending with more than two --', function(assert) {
+  let tokens = tokenize('<!-- A questionable but legal comment --->');
+  assert.deepEqual(tokens, [comment(' A questionable but legal comment -')]);
+
+  tokens = tokenize('<!-- A questionable but legal comment--->');
+  assert.deepEqual(tokens, [comment(' A questionable but legal comment-')]);
+
+  tokens = tokenize('<!-- A questionable but legal comment - --->');
+  assert.deepEqual(tokens, [comment(' A questionable but legal comment - -')]);
+
+  tokens = tokenize('<!-- A questionable but legal comment -- --->');
+  assert.deepEqual(tokens, [comment(' A questionable but legal comment -- -')]);
+
+  tokens = tokenize('<!-- A questionable but legal comment ------>');
+  assert.deepEqual(tokens, [comment(' A questionable but legal comment ----')]);
+});
+
+QUnit.test('A (buggy) comment starting with more than two --', function(assert) {
+  let tokens = tokenize('<!--- Questionable but legal -->');
+  assert.deepEqual(tokens, [comment('- Questionable but legal ')]);
+
+  tokens = tokenize('<!---Questionable but legal -->');
+  assert.deepEqual(tokens, [comment('-Questionable but legal ')]);
 });
 
 QUnit.test('Character references are expanded', function(assert) {


### PR DESCRIPTION
Comments ending with more than two dashes are not terminated correctly, resulting in markup following these comments to be included. `<!--Comment---><div>Markup</div>` is tokenized as a comment of `Comment---><div>Markup</div>`.

Comments starting with three dashes have their first character clipped. `<!---Comment-->` is tokenized as a comment of `omment`.